### PR TITLE
Fix email input type from text to email

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,7 @@
                     
                     <div class="form-group">
                         <label for="userEmail">📧 Email:</label>
-                        <!-- HTML BUG: Wrong input type - should be type="email" -->
-                        <input type="text" id="userEmail" required placeholder="Enter email address">
+                        <input type="email" id="userEmail" required placeholder="Enter email address">
                     </div>
                 </div>
                 


### PR DESCRIPTION
**PR Generated by testRigor CodeGen AI Agent**
## Summary
Changed the input type for the email field from "text" to "email" to ensure proper email validation and enable browser-native email input features. Removed the comment indicating this was a bug.
### Test case error
'text' is supposed to contain 'email', but it doesn't
### Additional context
Input type must be email
### Test case run
- https://app.testrigor.com/suites/hqu2kRT6mQdnThLWn/runs/yXqS2s8swxmtzEf4D
