### PR TITLE
Fix email input type from text to email

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,7 @@
                     
                     <div class="form-group">
                         <label for="userEmail">📧 Email:</label>
-                        <!-- HTML BUG: Wrong input type - should be type="email" -->
-                        <input type="text" id="userEmail" required placeholder="Enter email address">
+                        <input type="email" id="userEmail" required placeholder="Enter email address">
                     </div>
                 </div>
                 


### PR DESCRIPTION
**PR Generated by testRigor CodeGen AI Agent**
## Summary
Changed the input type attribute for the email field from "text" to "email" to ensure proper email validation and enable browser-native email input features. This fixes the HTML bug where the wrong input type was being used for the userEmail field.
### Test case error
'text' is supposed to contain 'email', but it doesn't
### Additional context
input type for the field should be email not text
### Test case run
- https://app.testrigor.com/suites/8wErBb3jLejnL2k9E/runs/Mwj3cmDn783wEKf2A
